### PR TITLE
Allow to disable the bucket policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ resource "aws_cloudfront_origin_access_identity" "this" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_s3_bucket_policy" "this" {
+  count  = var.enable_bucket_policy == true ? 1 : 0
   bucket = var.bucket_id
   policy = data.aws_iam_policy_document.this.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,12 @@ variable "enabled" {
   default     = true
 }
 
+variable "enable_bucket_policy" {
+  description = "Whether the bucket policy shall be managed or not"
+  type        = bool
+  default     = true
+}
+
 variable "price_class" {
   description = "Price Class"
   type        = string


### PR DESCRIPTION
If you manage the bucket policy for example for CRR or SRR already outside
the module, you need to be able to handle the policy without the module.